### PR TITLE
Fix markdown-lint issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,31 @@
-biblatex-lncs
-=============
+# biblatex-lncs
 
 BiBLaTeX style for Springer Lecture Notes in Computer Science
 
-# Introduction
+## Introduction
 
 The code works with `biblatex 2.2` and it requires `biber 1.2` as backend. It
 extends the standard `BiBTeX` model by an `acronym` entry.
 
 ## Usage
 
-    \usepackage[backend=biber,
-      style=lncs
-    ]{biblatex}
+```latex
+\usepackage[backend=biber,
+  style=lncs
+]{biblatex}
+```
 
-# Status
+## Status
+
 I intend to maintain this fork and gladly accept pull requests and issues.
 
-# License
+## License
+
 Copyright (c) 2018 Merlin Göttlinger
 
-forked from https://github.com/neapel/biblatex-lncs.git,
-who forked from https://github.com/jossco/biblatex-lncs.git, by Joseph Scott
-who forked from https://github.com/gvdgdo/biblatex-lncs.git, by Guido Governatori
+Forked from <https://github.com/neapel/biblatex-lncs.git>,
+who forked from <https://github.com/jossco/biblatex-lncs.git>, by Joseph Scott
+who forked from <https://github.com/gvdgdo/biblatex-lncs.git>, by Guido Governatori
 
 This package may be distributed under the terms of the LaTeX Project
 Public License, as described in lppl.txt in the base LaTeX distribution.


### PR DESCRIPTION
Applies the rules of [markdown-lint](https://github.com/DavidAnson/markdownlint) to have the `README.md` file consistently typeset.