### PR TITLE
Initial GitHub workflow including packaging a CTAN archive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Build
+on: [push, pull_request]
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v2
+      - name: pdflatex test.tex
+        uses: dante-ev/latex-action@edge
+        with:
+          root_file: test.tex
+          compiler: pdflatex
+          args: -interaction=nonstopmode -shell-escape
+      - name: release.sh
+        uses: dante-ev/latex-action@edge
+        with:
+          entrypoint: ./release.sh
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ctan
+          path: biblatex-lncs.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,21 @@ jobs:
     steps:
       - name: Set up Git repository
         uses: actions/checkout@v2
+      - name: Create llncs.cls
+        id: createllncs
+        shell: bash
+        run: |
+           mkdir tmp
+           if [ "$LLNCS_CLS" == "" ]; then
+             echo ::set-output name=lncsclspresent::false
+           else
+             echo ::set-output name=lncsclspresent::true
+             echo "$LLNCS_CLS" > llncs.cls
+           fi
+        env:
+          LLNCS_CLS: ${{secrets.LLNCS_CLS}}
       - name: pdflatex test.tex
+        if: ${{ steps.createllncs.outputs.lncsclspresent }}
         uses: dante-ev/latex-action@edge
         with:
           root_file: test.tex

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+ctanify --notds LICENSE README.md lncs.bbx lncs.cbx lncs.dbx test.bib test.tex

--- a/release.sh
+++ b/release.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-ctanify --notds LICENSE README.md lncs.bbx lncs.cbx lncs.dbx test.bib test.tex
+ctanify --notds --pkgname biblatex-lncs LICENSE README.md lncs.bbx lncs.cbx lncs.dbx test.bib test.tex


### PR DESCRIPTION
This adds an initial GitHub workflow (AKA GitHub action) for a) checking the build and b) creating a CTAN distribution archive.

One has to create the secret `LLNCS_CLS` containing the contents of the `lncs.cls` file to get build check of `test.tex` working. The URL to create that secret should be https://github.com/mgttlinger/biblatex-lncs/settings/secrets/actions

![grafik](https://user-images.githubusercontent.com/1366654/129634894-84f3b495-d57f-40e9-bae9-7e0243c916de.png)
