### PR TITLE
New implementation for "et al." in italics and "eds." in brackets.

### DIFF
--- a/lncs.bbx
+++ b/lncs.bbx
@@ -132,31 +132,20 @@
     {}%
 }
 
-\DeclareNameFormat{author}{%
-  \nameparts{#1}%
-  \usebibmacro{name:family-given}
-          {\namepartfamily}
-          {\namepartgiveni}
-          {\namepartprefix}
-          {\namepartsuffix}
-  \ifthenelse{\value{listcount}<\value{liststop}}
-    {\addcomma\space}%
-    {\ifmorenames{\addcomma~\bibstring[\emph]{andothers}:}{}}%
-}
+\renewbibmacro*{name:andothers}{% from biblatex.def
+  \ifboolexpr{
+    test {\ifnumequal{\value{listcount}}{\value{liststop}}}
+    and
+    test \ifmorenames
+  }
+    {\ifnumgreater{\value{liststop}}{1}
+       {\finalandcomma}
+       {}%
+     \printdelim{andothersdelim}\bibstring[\emph]{andothers}} % added: \emph
+    {}}
 
-\DeclareNameFormat{editor}{%
-  \nameparts{#1}%
-  \usebibmacro{name:family-given}
-          {\namepartfamily}
-          {\namepartgiveni}
-          {\namepartprefix}
-          {\namepartsuffix}
-    \ifthenelse{\value{listcount}<\value{liststop}}
-    {\addcomma\space}%
-    {\ifmorenames{\addcomma~\bibstring[\emph]{andothers}}\space\ifthenelse{\value{listcount}>1}
-      {(\bibstring{editors})}
-      {(\bibstring{editor})}}%
-}
+\DeclareFieldFormat{editortype}{(#1)}
+\DeclareDelimFormat{editortypedelim}{\space}
 
 \DeclareBibliographyDriver{article}{%
   \usebibmacro{bibindex}%


### PR DESCRIPTION
The intention of the authors and editors definitions here seemed to be to 1) turn "et al." into italics and 2) turn "ed." and "eds." into brackets. I had some ugly results with the current implementation like stray "," and double "eds." with and without brackets. This pull request fixes the issues I had and provides a solution that uses more fine-grained biblatex APIs  instead of re-implementing name formats.