### PR TITLE
Fix URL issue #12

### DIFF
--- a/lncs.bbx
+++ b/lncs.bbx
@@ -67,6 +67,28 @@
   }
 }
 
+\DeclareSourcemap{
+  \maps[datatype=bibtex]{
+    \map{
+      \step[ % copies url to doi field if it starts with https://doi.org/ or http://dx.doi.org/. This does not overwrite doi.
+      fieldsource=url,
+      match=\regexp{https?://(dx.)?doi.org/(.+)},
+      fieldtarget=doi,
+      ]
+      \step[ % removes https://doi.org/ or http://dx.doi.org/ string from doi field
+      fieldsource=doi,
+      match=\regexp{https?://(dx.)?doi.org/(.+)},
+      replace=\regexp{$2}
+      ]
+    }
+    \map{ % removes url + urldate field from all entries that have a doi field with https://doi.org/ or http://dx.doi.org/ string. If url is undefined or does not match \regexp{https?://(dx.)?doi.org/(.+)}, then processing of this \map immediately terminates.
+      \step[fieldsource=url, match=\regexp{https?://(dx.)?doi.org/(.+)}, final]
+      \step[fieldset=url, null]
+      \step[fieldset=urldate, null]
+    }
+  }
+}
+
 \renewbibmacro{journal}{%
   \iffieldundef{shortjournal}
   {\printfield{journaltitle}}

--- a/lncs.bbx
+++ b/lncs.bbx
@@ -36,47 +36,47 @@
 \DeclareFieldFormat{url}{\url{#1}}
 \DeclareFieldFormat[article]{volume}{\textbf{#1}}
 \DeclareFieldFormat{doi}{\url{https://doi.org/#1}}
-%%%
+%%% 
 
 \defbibenvironment{bibliography}
-  {\list
-     {\printfield[labelnumberwidth]{labelnumber}}
-     {\setlength{\labelwidth}{\labelnumberwidth}%
-      \setlength{\leftmargin}{\labelwidth}%
-      \setlength{\labelsep}{.5em}%
-      \addtolength{\leftmargin}{\labelsep}%
-      \setlength{\itemsep}{\bibitemsep}%
-      \setlength{\parsep}{\bibparsep}}%
-      \renewcommand*{\makelabel}[1]{\hss##1}}
-  {\endlist}
-  {\item}
+{\list
+  {\printfield[labelnumberwidth]{labelnumber}}
+  {\setlength{\labelwidth}{\labelnumberwidth}%
+    \setlength{\leftmargin}{\labelwidth}%
+    \setlength{\labelsep}{.5em}%
+    \addtolength{\leftmargin}{\labelsep}%
+    \setlength{\itemsep}{\bibitemsep}%
+    \setlength{\parsep}{\bibparsep}}%
+  \renewcommand*{\makelabel}[1]{\hss##1}}
+{\endlist}
+{\item}
 
 \DeclareStyleSourcemap{
   \maps[datatype=bibtex]{
     \map{
       \step[fieldsource=series,
-        match=\regexp{Lecture\s+Notes\s+in\s+Computer\s+Science},
-        replace={LNCS}]
+      match=\regexp{Lecture\s+Notes\s+in\s+Computer\s+Science},
+      replace={LNCS}]
       \step[fieldsource=series,
-        match=\regexp{Lecture\s+Notes\s+in\s+Artificial\s+Intelligence},
-        replace={LNAI}]
+      match=\regexp{Lecture\s+Notes\s+in\s+Artificial\s+Intelligence},
+      replace={LNAI}]
       \step[fieldsource=series,
-        match=\regexp{Lecture\s+Notes\s+in\s+Business\s+Information\s+Processing},
-        replace={LNBIP}]
+      match=\regexp{Lecture\s+Notes\s+in\s+Business\s+Information\s+Processing},
+      replace={LNBIP}]
     }
   }
 }
 
 \renewbibmacro{journal}{%
   \iffieldundef{shortjournal}
-    {\printfield{journaltitle}}
-    {\printfield[journal]{shortjournal}}%
+  {\printfield{journaltitle}}
+  {\printfield[journal]{shortjournal}}%
 }
 
 \renewbibmacro*{institution+location+date}{%
   \iflistundef{institution}
-    {\setunit*{\addcomma\space}}
-    {\setunit*{\addcolon\space}}%
+  {\setunit*{\addcomma\space}}
+  {\setunit*{\addcolon\space}}%
   \printlist{institution}%
   \setunit*{\addcomma\space}
   \printlist{location}%
@@ -86,40 +86,40 @@
 
 \newbibmacro{journal:info}{
   \iffieldundef{volume}
-    {\iffieldundef{year}
-      {\iffieldundef{pubstate}
-        {}
-        {(\printfield{pubstate})}}
-      {\printfield{year}}}
-    {\printfield{volume}%
-      \iffieldundef{number}{}{(\printfield{number})}%
-      \iffieldundef{pages}
-        {\addspace\printfield{year}}
-        {\addcomma\addspace\printfield{pages}\addspace\printfield{year}}
-    }
+  {\iffieldundef{year}
+    {\iffieldundef{pubstate}
+      {}
+      {(\printfield{pubstate})}}
+    {\printfield{year}}}
+  {\printfield{volume}%
+    \iffieldundef{number}{}{(\printfield{number})}%
+    \iffieldundef{pages}
+    {\addspace\printfield{year}}
+    {\addcomma\addspace\printfield{pages}\addspace\printfield{year}}
+  }
 }
 
 \newbibmacro{proceedingstitle}{%
   \iffieldundef{booktitle}
-    {\printfield{eventtitle}}
-    {\printfield{booktitle}}
+  {\printfield{eventtitle}}
+  {\printfield{booktitle}}
 }
 
 \newbibmacro{acronym/booktitle}{%
   \iffieldundef{acronym}
-    {\usebibmacro{proceedingstitle}}
-    {\printfield{acronym}}%
-    \addperiod\addspace
+  {\usebibmacro{proceedingstitle}}
+  {\printfield{acronym}}%
+  \addperiod\addspace
 }
 
 \newbibmacro{publisher+location}{%
   \iftoggle{lncs:lncs}
-    {\printtext{Springer, Heidelberg}}
-    {\printlist{publisher}%
-      \iflistundef{location}
-        {}
-        {\addcomma\addspace\printlist{location}}%
-    }%
+  {\printtext{Springer, Heidelberg}}
+  {\printlist{publisher}%
+    \iflistundef{location}
+    {}
+    {\addcomma\addspace\printlist{location}}%
+  }%
 }
 
 \renewbibmacro{finentry}{\settoggle{lncs:lncs}{false}\finentry}
@@ -129,8 +129,8 @@
 
 \newbibmacro{doi}{%
   \iftoggle{bbx:doi}
-    {\printfield{doi}}
-    {}%
+  {\printfield{doi}}
+  {}%
 }
 
 \renewbibmacro*{name:andothers}{% from biblatex.def
@@ -139,11 +139,11 @@
     and
     test \ifmorenames
   }
-    {\ifnumgreater{\value{liststop}}{1}
-       {\finalandcomma}
-       {}%
-     \printdelim{andothersdelim}\bibstring[\emph]{andothers}} % added: \emph
-    {}}
+  {\ifnumgreater{\value{liststop}}{1}
+    {\finalandcomma}
+    {}%
+    \printdelim{andothersdelim}\bibstring[\emph]{andothers}} % added: \emph
+  {}}
 
 \DeclareFieldFormat{editortype}{(#1)}
 \DeclareDelimFormat{editortypedelim}{\space}
@@ -151,19 +151,18 @@
 \DeclareNameFormat{author}{%
   \ifdefvoid{\namepartprefix}{}{\namepartprefix\space}\namepartfamily, \namepartgiveni%
   \ifthenelse{\value{listcount}<\value{liststop}}
-    {\addcomma\space}%
-    {}%
+  {\addcomma\space}%
+  {}%
   \usebibmacro{name:andothers}%
 }
 \DeclareNameFormat{editor}{%
   \ifdefvoid{\namepartprefix}{}{\namepartprefix\space}\namepartfamily, \namepartgiveni%
   \ifthenelse{\value{listcount}<\value{liststop}}
-    {\addcomma\space}%
-    {\space\ifthenelse{\value{listcount}>1}
-      {(\bibstring{editors})}
-      {(\bibstring{editor})}}%
+  {\addcomma\space}%
+  {\space\ifthenelse{\value{listcount}>1}
+    {(\bibstring{editors})}
+    {(\bibstring{editor})}}%
 }
-
 
 \DeclareBibliographyDriver{article}{%
   \usebibmacro{bibindex}%
@@ -180,10 +179,10 @@
   \usebibmacro{pageref}%
   \newunit\newblock
   \iftoggle{bbx:related}
-    {\usebibmacro{related:init}%
-     \usebibmacro{related}}
-    {}%
-  \usebibmacro{doi}%
+  {\usebibmacro{related:init}%
+    \usebibmacro{related}}
+  {}%
+  \usebibmacro{doi+eprint+url}%
   \nopunct%
   \usebibmacro{finentry}%
 }
@@ -192,8 +191,8 @@
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%
   \ifnameundef{author}
-    {\printnames{editor}}
-    {\printnames{author}}%
+  {\printnames{editor}}
+  {\printnames{author}}%
   \setunit*{\labelnamepunct}\newblock%
   \usebibmacro{title}%
   \newunit%
@@ -206,9 +205,9 @@
   \usebibmacro{pageref}%
   \newunit\newblock
   \iftoggle{bbx:related}
-    {\usebibmacro{related:init}%
-     \usebibmacro{related}}
-    {}%
+  {\usebibmacro{related:init}%
+    \usebibmacro{related}}
+  {}%
   \nopunct%
   \usebibmacro{finentry}%
 }
@@ -224,28 +223,28 @@
   \printnames{editor}%
   \newunit
   \iffieldundef{series}
-    {\iftoggle{lncs:abbrev}
-      {\usebibmacro{acronym/booktitle}}
-      {\usebibmacro{proceedingstitle}\newunit}%
-    }%
-    {\ifboolexpr{
-        test {\iffieldequalstr{series}{LNAI}}
-        or
-        test {\iffieldequalstr{series}{LNCS}}
-        or
-        test {\iffieldequalstr{series}{LNBIP}}
-      }
-      {\settoggle{lncs:lncs}{true}%
-       \usebibmacro{acronym/booktitle}%
-       \printfield{series}
-       \addcomma\newunit
-       \iffieldundef{volume}
-         {\iffieldundef{number}{}{vol.\addspace\printfield{number}\addcomma}}
-         {\printfield{volume}}%
-      }%
-      {\usebibmacro{acronym/booktitle}%
-       \printfield{series}}%
+  {\iftoggle{lncs:abbrev}
+    {\usebibmacro{acronym/booktitle}}
+    {\usebibmacro{proceedingstitle}\newunit}%
+  }%
+  {\ifboolexpr{
+      test {\iffieldequalstr{series}{LNAI}}
+      or
+      test {\iffieldequalstr{series}{LNCS}}
+      or
+      test {\iffieldequalstr{series}{LNBIP}}
     }
+    {\settoggle{lncs:lncs}{true}%
+      \usebibmacro{acronym/booktitle}%
+      \printfield{series}
+      \addcomma\newunit
+      \iffieldundef{volume}
+      {\iffieldundef{number}{}{vol.\addspace\printfield{number}\addcomma}}
+      {\printfield{volume}}%
+    }%
+    {\usebibmacro{acronym/booktitle}%
+      \printfield{series}}%
+  }
   \iffieldundef{pages}{}{\setunit{\addcomma\space}\printfield{pages}}%
   \newunit%
   \usebibmacro{publisher+location}%
@@ -257,10 +256,10 @@
   \usebibmacro{pageref}%
   \newunit\newblock
   \iftoggle{bbx:related}
-    {\usebibmacro{related:init}%
-     \usebibmacro{related}}
-    {}%
-  \usebibmacro{doi}%
+  {\usebibmacro{related:init}%
+    \usebibmacro{related}}
+  {}%
+  \usebibmacro{doi+eprint+url}%
   \nopunct%
   \usebibmacro{finentry}%
 }
@@ -271,16 +270,16 @@
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%
   \printnames{author}
-  %\setunit*{\addcolon\space}
+  % \setunit*{\addcolon\space}
   \setunit*{\labelnamepunct}\newblock%
   \usebibmacro{title}
-  %\printfield[article]{title}
+  % \printfield[article]{title}
   \newunit\newblock
-  %\printtext{In:}
+  % \printtext{In:}
   \usebibmacro{in:}%
   \usebibmacro{maintitle+booktitle}%
   \newunit\newblock
-  %\printnames{editor}
+  % \printnames{editor}
   \usebibmacro{byeditor+others}
   \newunit
   \iffieldundef{pages}{}{\addcomma\addspace\printfield{pages}}
@@ -294,10 +293,10 @@
   \usebibmacro{pageref}%
   \newunit\newblock
   \iftoggle{bbx:related}
-    {\usebibmacro{related:init}%
-     \usebibmacro{related}}
-    {}%
-  \usebibmacro{doi}%
+  {\usebibmacro{related:init}%
+    \usebibmacro{related}}
+  {}%
+  \usebibmacro{doi+eprint+url}%
   \nopunct%
   \usebibmacro{finentry}%
 }
@@ -335,8 +334,8 @@
   \printfield{year}%
   \newunit\newblock
   \iftoggle{bbx:eprint}
-    {\usebibmacro{eprint}}
-    {}%
+  {\usebibmacro{eprint}}
+  {}%
   \newunit\newblock
   \usebibmacro{url+urldate}%
   \newunit\newblock
@@ -345,9 +344,9 @@
   \usebibmacro{pageref}%
   \newunit\newblock
   \iftoggle{bbx:related}
-    {\usebibmacro{related:init}%
-     \usebibmacro{related}}
-    {}%
+  {\usebibmacro{related:init}%
+    \usebibmacro{related}}
+  {}%
   \usebibmacro{doi}%
   \nopunct%
   \usebibmacro{finentry}
@@ -385,9 +384,9 @@
   \usebibmacro{pageref}%
   \newunit\newblock
   \iftoggle{bbx:related}
-    {\usebibmacro{related:init}%
-     \usebibmacro{related}}
-    {}%
+  {\usebibmacro{related:init}%
+    \usebibmacro{related}}
+  {}%
   \usebibmacro{finentry}
 }
 
@@ -401,10 +400,9 @@
   \printfield{type}
   \addcomma\newunit
   \usebibmacro{institution+location+date}%
-  \usebibmacro{doi}%
+  \usebibmacro{doi+eprint+url}%
   \usebibmacro{finentry}%
 }
-
 
 \DeclareBibliographyDriver{report}{%
   \usebibmacro{bibindex}%
@@ -430,27 +428,27 @@
   \printfield{pagetotal}%
   \newunit\newblock
   \iftoggle{bbx:isbn}
-    {\printfield{isrn}}
-    {}%
+  {\printfield{isrn}}
+  {}%
   \newunit\newblock
   \usebibmacro{institution+location+date}%
-  %\newunit\newblock
+  % \newunit\newblock
   \newunit\newblock
   \usebibmacro{addendum+pubstate}%
   \setunit{\bibpagerefpunct}\newblock
   \usebibmacro{pageref}%
   \newunit\newblock
   \iftoggle{bbx:related}
-    {\usebibmacro{related:init}%
-     \usebibmacro{related}}
-    {}%
-  \usebibmacro{doi}%
+  {\usebibmacro{related:init}%
+    \usebibmacro{related}}
+  {}%
+  \usebibmacro{doi+eprint+url}%
   \nopunct%
   \usebibmacro{finentry}
 }
 
 % \DeclareBibliographyDriver{*}{%
-%   Titolo: \printfield{title}\\
-%   Autore: \printnames{author}\\
-%   Prova:  \printfield{acronym}%
+% Titolo: \printfield{title}\\
+% Autore: \printnames{author}\\
+% Prova: \printfield{acronym}%
 % }


### PR DESCRIPTION
+ Fix the issue "The url field is being discarded #12"
  - by replacing   \usebibmacro{doi} →  \usebibmacro{doi+eprint+url}, except for @online
  
+ In addition, add a new feature to suppress duplicate ”https://doi.org/*" URLs
  - see, https://tex.stackexchange.com/questions/119136/biblatex-convert-doi-url-into-doi-field
